### PR TITLE
fix #1 bug concerning unavailable port in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ app.get("/", function(req,res){
 	res.render("landing");
 });
 
-app.listen(8000, function(){
-	console.log("Server is listening...")
+app.listen(process.argv[2], function(){
+	console.log("server listening...");
 });
+


### PR DESCRIPTION
I fixed the bug by changing the static port number to be a dynamic value in the app.js file, app.listen().
Now, when you run the app you need to execute 'node app.js *port number*' and it will run on that port.